### PR TITLE
[codex] Fix paper12 publication link

### DIFF
--- a/content/papers/paper12/index.md
+++ b/content/papers/paper12/index.md
@@ -7,15 +7,15 @@ author: [
     "Øystein Sørensen",
     "Ethan M. McCormick"
 ]
-description: "This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision."
+description: "This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research."
 summary: "Dynamic structural equation models have become extremely popular for analysis of intensive longitudinal data in the social sciences. One outstanding problem is how to handle nonlinear trends and cycles, and in this paper we propose to do this in a very flexible manner using regression splines. We test the methods in simulation studies, and then illustrate them by analyzing a diary data set on alcohol consumption and stress. Open-source Stan code is available from our OSF repository. Published in Multivariate Behavioral Research."
 cover:
     image: "paper12.png"
     
     relative: false
 editPost:
-    URL: "https://doi.org/10.48550/arXiv.2412.13644"
-    Text: "Published in Multivariate Behavioral Research"
+    URL: "https://doi.org/10.1080/00273171.2025.2507297"
+    Text: "Multivariate Behavioral Research"
 
 ---
 
@@ -62,4 +62,3 @@ Sørensen, Ø., & McCormick, E. M. (2025). Modeling Cycles, Trends and Time-Vary
     eprint = {https://doi.org/10.1080/00273171.2025.2507297}
 }
 ```
-

--- a/public/index.html
+++ b/public/index.html
@@ -225,10 +225,10 @@
         <div>
           <h3><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h3>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>

--- a/public/papers/index.html
+++ b/public/papers/index.html
@@ -167,7 +167,7 @@
         <div>
           <h2><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h2>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           
           <ul class="tag-list">
             <li>DSEM</li><li>intensive longitudinal data</li><li>regression splines</li><li>smoothing</li><li>Stan</li>
@@ -175,7 +175,7 @@
           
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>

--- a/public/papers/paper12/index.html
+++ b/public/papers/paper12/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="index, follow">
 <title>Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines | Øystein Sørensen</title>
-<meta name="description" content="This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.">
+<meta name="description" content="This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.">
 <meta name="author" content="Øystein Sørensen">
 <link rel="canonical" href="https://osorensen.no/papers/paper12/">
 <link rel="icon" href="/favicon.ico">
@@ -76,10 +76,10 @@
         <span>January 2025</span>
         <span>Øystein Sørensen, Ethan M. McCormick</span>
       </div>
-      <p class="lead">This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+      <p class="lead">This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
       
       
-      <p class="single-action"><a class="button" href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a></p>
+      <p class="single-action"><a class="button" href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a></p>
       
     </div>
   </header>

--- a/public/tags/dsem/index.html
+++ b/public/tags/dsem/index.html
@@ -128,7 +128,7 @@
         <div>
           <h2><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h2>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           
           <ul class="tag-list">
             <li>DSEM</li><li>intensive longitudinal data</li><li>regression splines</li><li>smoothing</li><li>Stan</li>
@@ -136,7 +136,7 @@
           
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>

--- a/public/tags/intensive-longitudinal-data/index.html
+++ b/public/tags/intensive-longitudinal-data/index.html
@@ -128,7 +128,7 @@
         <div>
           <h2><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h2>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           
           <ul class="tag-list">
             <li>DSEM</li><li>intensive longitudinal data</li><li>regression splines</li><li>smoothing</li><li>Stan</li>
@@ -136,7 +136,7 @@
           
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>

--- a/public/tags/regression-splines/index.html
+++ b/public/tags/regression-splines/index.html
@@ -90,7 +90,7 @@
         <div>
           <h2><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h2>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           
           <ul class="tag-list">
             <li>DSEM</li><li>intensive longitudinal data</li><li>regression splines</li><li>smoothing</li><li>Stan</li>
@@ -98,7 +98,7 @@
           
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>

--- a/public/tags/smoothing/index.html
+++ b/public/tags/smoothing/index.html
@@ -90,7 +90,7 @@
         <div>
           <h2><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h2>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           
           <ul class="tag-list">
             <li>DSEM</li><li>intensive longitudinal data</li><li>regression splines</li><li>smoothing</li><li>Stan</li>
@@ -98,7 +98,7 @@
           
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>

--- a/public/tags/stan/index.html
+++ b/public/tags/stan/index.html
@@ -90,7 +90,7 @@
         <div>
           <h2><a href="/papers/paper12/">Modeling Cycles, Trends and Time-Varying Effects in Dynamic Structural Equation Models with Regression Splines</a></h2>
           <p class="byline">Øystein Sørensen, Ethan M. McCormick</p>
-          <p>This paper considers rank and preference modeling for the case in which data arrive sequentially, rather than in a batch. The goal is to compute the posterior distribution incrementally in time, so that it can be quickly updated when new data arrives. To this end, we develop a sequential Monte Carlo algorithm for the Bayesian Mallows model. arXiv preprint currently under revision.</p>
+          <p>This paper proposes regression splines for flexibly modeling nonlinear trends, cycles, and time-varying effects in dynamic structural equation models. Published in Multivariate Behavioral Research.</p>
           
           <ul class="tag-list">
             <li>DSEM</li><li>intensive longitudinal data</li><li>regression splines</li><li>smoothing</li><li>Stan</li>
@@ -98,7 +98,7 @@
           
           <div class="inline-actions">
             <a href="/papers/paper12/">Details</a>
-            <a href="https://doi.org/10.48550/arXiv.2412.13644" target="_blank" rel="noopener noreferrer">Published in Multivariate Behavioral Research</a>
+            <a href="https://doi.org/10.1080/00273171.2025.2507297" target="_blank" rel="noopener noreferrer">Multivariate Behavioral Research</a>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary

- Fix the paper12 publication action URL so the Multivariate Behavioral Research link points to the journal DOI instead of the Bayesian Analysis arXiv DOI.
- Replace the copied Bayesian Mallows description on paper12 with a DSEM/regression-splines description.
- Regenerate the tracked Hugo output pages that surface the paper12 description and publication link.

## Root Cause

The paper12 front matter had a copied `editPost.URL` and description from the Bayesian Mallows paper, so list/detail pages could send users to the wrong publication.

## Validation

- Ran `/opt/homebrew/bin/hugo --panicOnWarning`.
- Searched `content` and `public` for the wrong arXiv DOI and the copied Bayesian Mallows description in paper12-generated pages; no matches remained.