### PR TITLE
[codex] Remove CV button

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,7 +11,6 @@
       <div class="button-row">
         <a class="button" href="{{ "papers/" | relURL }}">Publications</a>
         <a class="button button--secondary" href="{{ "software/" | relURL }}">Software</a>
-        <a class="button button--secondary" href="{{ "cv.pdf" | relURL }}">CV</a>
       </div>
     </div>
     <div class="hero__media">

--- a/public/index.html
+++ b/public/index.html
@@ -90,7 +90,6 @@
       <div class="button-row">
         <a class="button" href="/papers/">Publications</a>
         <a class="button button--secondary" href="/software/">Software</a>
-        <a class="button button--secondary" href="/cv.pdf">CV</a>
       </div>
     </div>
     <div class="hero__media">


### PR DESCRIPTION
## Summary

Removes the homepage CV button that linked directly to `/cv.pdf`, which currently points to the template PDF rather than the actual CV.

## Impact

Visitors will no longer see or click through to the incorrect CV PDF from the homepage hero actions.

## Validation

- Confirmed no `cv.pdf` / `CV` homepage button references remain in `layouts/index.html` or `public/index.html`.
- Ran `hugo --destination <tempdir> --cleanDestinationDir --minify` successfully.